### PR TITLE
2HC対応

### DIFF
--- a/data/basic_types.xml
+++ b/data/basic_types.xml
@@ -1093,6 +1093,20 @@
 		<OEMName type="string">FAT12</OEMName>
 		<Description>MS-DOS for PC-9801 (2HD)</Description>
 	</DiskBasicType>
+	<DiskBasicType name="MSDOS-2HC" type="3" category="MSDOS">
+		<SectorsPerGroup>1</SectorsPerGroup>
+		<SidesPerDisk>2</SidesPerDisk>
+		<ManagedTrackNumber>0</ManagedTrackNumber>
+		<ReservedSectors>1</ReservedSectors>
+		<NumberOfFATs>2</NumberOfFATs>
+		<SectorsPerFAT>7</SectorsPerFAT>
+		<FATStartPosition>0</FATStartPosition>
+		<DirEntryCount>224</DirEntryCount>
+		<MediaID>0xf9</MediaID>
+		<JumpBoot type="string">\xeb\x3c\x90</JumpBoot>
+		<OEMName type="string">FAT12</OEMName>
+		<Description>MS-DOS for PC-AT (2HC)</Description>
+	</DiskBasicType>
 	<DiskBasicType name="MSDOS-2HD" type="3" category="MSDOS">
 		<SectorsPerGroup>1</SectorsPerGroup>
 		<SidesPerDisk>2</SidesPerDisk>

--- a/data/disk_types.xml
+++ b/data/disk_types.xml
@@ -1542,6 +1542,21 @@
 		<Description>, SectorBase10 [9SCFMT]</Description>
 		<Description lang="ja"> セクタ基準10 [9SCFMT]</Description>
 	</DiskType>
+	<DiskType name="2HD-80-15-1">
+		<SidesPerDisk>2</SidesPerDisk>
+		<TracksPerSide>80</TracksPerSide>
+		<SectorsPerTrack>15</SectorsPerTrack>
+		<SectorSize>512</SectorSize>
+		<Density>0x20</Density>
+		<Interleave>1</Interleave>
+		<DiskBasicTypes>
+			<Type p="major">MSDOS-2HC</Type>
+		</DiskBasicTypes>
+		<DensityName>2HD</DensityName>
+		<DensityName lang="ja">2HD</DensityName>
+		<Description>[PC-AT DOS]</Description>
+		<Description lang="ja">[PC-AT DOS]</Description>
+	</DiskType>
 	<DiskType name="2HD-80-18-1">
 		<SidesPerDisk>2</SidesPerDisk>
 		<TracksPerSide>80</TracksPerSide>


### PR DESCRIPTION
J3100シリーズなどで使用されていたIBM PC/AT互換機 1.2MB(2HC)の設定を追加しました。
追伸
L3 Disk Explorerにはすごくお世話になってます。素晴らしいソフトをありがとうございます。
